### PR TITLE
Remove example items and add empty state

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -115,30 +115,20 @@
         <button type="submit" class="button">Agendar</button>
       </form>
 
-      <aside class="schedule">
-        <header>
-          <h1>Agendamentos</h1>
-          <p>Visualize os agendamentos de acordo com o dia selecionado</p>
-        </header>
+        <aside class="schedule">
+          <header>
+            <h1>Agendamentos</h1>
+            <p>Visualize os agendamentos de acordo com o dia selecionado</p>
+          </header>
+          <p id="schedule-empty" class="schedule-empty" hidden>Nenhum agendamento disponível</p>
 
-        <section class="schedule-period">
+          <section class="schedule-period">
           <header>
             <img src="./src/assets/morning.svg" alt="Manhã" />
             <strong>Manhã</strong>
             <span>09h-12h</span>
           </header>
-          <ul id="period-morning" class="period">
-            <!-- Exemplo  -->
-            <li>
-              <strong>11:00</strong>
-              <span>Rodrigo Gonçalves</span>
-              <img
-                src="./src/assets/cancel.svg"
-                alt="Cancelar"
-                class="cancel-icon"
-              />
-            </li>
-          </ul>
+          <ul id="period-morning" class="period"></ul>
         </section>
 
         <section class="schedule-period">
@@ -147,18 +137,7 @@
             <strong>Tarde</strong>
             <span>13h-18h</span>
           </header>
-          <ul id="period-afternoon" class="period">
-            <!-- Exemplo -->
-            <li>
-              <strong>14:00</strong>
-              <span>Rodrigo Gonçalves</span>
-              <img
-                src="./src/assets/cancel.svg"
-                alt="Cancelar"
-                class="cancel-icon"
-              />
-            </li>
-          </ul>
+          <ul id="period-afternoon" class="period"></ul>
         </section>
 
         <section class="schedule-period">
@@ -167,18 +146,7 @@
             <strong>noite</strong>
             <span>19h-21h</span>
           </header>
-          <ul id="period-night" class="period">
-            <!-- Exemplo -->
-            <li>
-              <strong>19:00</strong>
-              <span>Rodrigo Gonçalves</span>
-              <img
-                src="./src/assets/cancel.svg"
-                alt="Cancelar"
-                class="cancel-icon"
-              />
-            </li>
-          </ul>
+          <ul id="period-night" class="period"></ul>
         </section>
       </aside>
     </div>

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
           <h1>Agendamentos</h1>
           <p>Visualize os agendamentos de acordo com o dia selecionado</p>
         </header>
+        <p id="schedule-empty" class="schedule-empty" hidden>Nenhum agendamento disponível</p>
 
         <section class="schedule-period">
           <header>
@@ -127,18 +128,7 @@
             <strong>Manhã</strong>
             <span>09h-12h</span>
           </header>
-          <ul id="period-morning" class="period">
-            <!-- Exemplo  -->
-            <li>
-              <strong>11:00</strong>
-              <span>Rodrigo Gonçalves</span>
-              <img
-                src="./src/assets/cancel.svg"
-                alt="Cancelar"
-                class="cancel-icon"
-              />
-            </li>
-          </ul>
+          <ul id="period-morning" class="period"></ul>
         </section>
 
         <section class="schedule-period">
@@ -147,18 +137,7 @@
             <strong>Tarde</strong>
             <span>13h-18h</span>
           </header>
-          <ul id="period-afternoon" class="period">
-            <!-- Exemplo -->
-            <li>
-              <strong>14:00</strong>
-              <span>Rodrigo Gonçalves</span>
-              <img
-                src="./src/assets/cancel.svg"
-                alt="Cancelar"
-                class="cancel-icon"
-              />
-            </li>
-          </ul>
+          <ul id="period-afternoon" class="period"></ul>
         </section>
 
         <section class="schedule-period">
@@ -167,18 +146,7 @@
             <strong>noite</strong>
             <span>19h-21h</span>
           </header>
-          <ul id="period-night" class="period">
-            <!-- Exemplo -->
-            <li>
-              <strong>19:00</strong>
-              <span>Rodrigo Gonçalves</span>
-              <img
-                src="./src/assets/cancel.svg"
-                alt="Cancelar"
-                class="cancel-icon"
-              />
-            </li>
-          </ul>
+          <ul id="period-night" class="period"></ul>
         </section>
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- strip the static example appointments from each schedule list
- keep the schedule lists for dynamic population
- add hidden empty-state message element

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c937ff4d08322842049b18bf9f001